### PR TITLE
Add dopamine benchmark

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dopamine/submodule"]
+	path = dopamine/submodule
+	url = ssh://git@github.com/google/dopamine

--- a/dopamine/.gitignore
+++ b/dopamine/.gitignore
@@ -1,0 +1,1 @@
+Roms.rar

--- a/dopamine/Dockerfile
+++ b/dopamine/Dockerfile
@@ -1,1 +1,0 @@
-FROM submodule/docker/atari

--- a/dopamine/Dockerfile
+++ b/dopamine/Dockerfile
@@ -1,0 +1,1 @@
+FROM submodule/docker/atari

--- a/dopamine/README.md
+++ b/dopamine/README.md
@@ -1,0 +1,9 @@
+To run:
+```bash
+# grab dopamine submodule
+git submodule init
+git submodule update
+./build.sh
+```
+
+This will output the results of the `time` command. Intermediate logging will also post steps/second for "training iterations".

--- a/dopamine/atari/Dockerfile
+++ b/dopamine/atari/Dockerfile
@@ -1,0 +1,21 @@
+# Note: this Dockerfile expects that Atari ROMs retrieved following the
+# instructions from atari-py: https://github.com/openai/atari-py#roms.
+# It should specify a directory (e.g. ~/roms) that contains ROMS.rar.
+# It should be run from the rom directory.
+
+ARG base_image=dopamine/core
+FROM ${base_image}
+
+# Copy ROMs into the image.
+RUN mkdir /root/roms
+
+RUN apt-get install rar unzip -y
+RUN pip install atari_py ale-py
+
+COPY ./Roms.rar /root/roms/
+RUN rar x /root/roms/Roms.rar /root/roms/
+
+RUN python -m atari_py.import_roms /root/roms
+RUN ale-import-roms /root/roms/ROMS
+
+COPY ./configs /configs

--- a/dopamine/build.sh
+++ b/dopamine/build.sh
@@ -1,4 +1,8 @@
-mkdir roms/
-wget http://www.atarimania.com/roms/Roms.rar roms/
+if [ ! -f ./Roms.rar ]; then
+    wget http://www.atarimania.com/roms/Roms.rar -O ./Roms.rar
+fi
 
-docker build
+docker build -f core/Dockerfile -t dopamine/core .
+docker build -f atari/Dockerfile -t dopamine/atari .
+
+time docker run --privileged --gpus all --name rainbow_atari -it dopamine/atari  python -um dopamine.discrete_domains.train --base_dir /tmp --gin_files /configs/rainbow.gin

--- a/dopamine/build.sh
+++ b/dopamine/build.sh
@@ -1,0 +1,4 @@
+mkdir roms/
+wget http://www.atarimania.com/roms/Roms.rar roms/
+
+docker build

--- a/dopamine/configs/rainbow.gin
+++ b/dopamine/configs/rainbow.gin
@@ -1,0 +1,36 @@
+# Hyperparameters follow Hessel et al. (2018), except for sticky_actions,
+# which was False (not using sticky actions) in the original paper.
+import dopamine.jax.agents.rainbow.rainbow_agent
+import dopamine.discrete_domains.atari_lib
+import dopamine.discrete_domains.run_experiment
+import dopamine.replay_memory.prioritized_replay_buffer
+
+JaxRainbowAgent.num_atoms = 51
+JaxRainbowAgent.vmax = 10.
+JaxRainbowAgent.gamma = 0.99
+JaxRainbowAgent.update_horizon = 3
+JaxRainbowAgent.min_replay_history = 32  # agent steps
+JaxRainbowAgent.update_period = 4
+JaxRainbowAgent.target_update_period = 8000  # agent steps
+JaxRainbowAgent.epsilon_train = 0.01
+JaxRainbowAgent.epsilon_eval = 0.001
+JaxRainbowAgent.epsilon_decay_period = 250000  # agent steps
+JaxRainbowAgent.replay_scheme = 'prioritized'
+
+# Note these parameters are different from C51's.
+create_optimizer.learning_rate = 0.0000625
+create_optimizer.eps = 0.00015
+
+atari_lib.create_atari_environment.game_name = 'Pong'
+# Sticky actions with probability 0.25, as suggested by (Machado et al., 2017).
+atari_lib.create_atari_environment.sticky_actions = True
+create_runner.schedule = 'continuous_train'
+create_agent.agent_name = 'jax_rainbow'
+create_agent.debug_mode = True
+Runner.num_iterations = 33
+Runner.training_steps = 15000  # agent steps
+Runner.evaluation_steps = 125000  # agent steps
+Runner.max_steps_per_episode = 27000  # agent steps
+
+OutOfGraphPrioritizedReplayBuffer.replay_capacity = 1000000
+OutOfGraphPrioritizedReplayBuffer.batch_size = 32

--- a/dopamine/configs/rainbow.gin
+++ b/dopamine/configs/rainbow.gin
@@ -27,9 +27,9 @@ atari_lib.create_atari_environment.sticky_actions = True
 create_runner.schedule = 'continuous_train'
 create_agent.agent_name = 'jax_rainbow'
 create_agent.debug_mode = True
-Runner.num_iterations = 33
+Runner.num_iterations = 4
 Runner.training_steps = 15000  # agent steps
-Runner.evaluation_steps = 125000  # agent steps
+Runner.evaluation_steps = 7500  # agent steps
 Runner.max_steps_per_episode = 27000  # agent steps
 
 OutOfGraphPrioritizedReplayBuffer.replay_capacity = 1000000

--- a/dopamine/core/Dockerfile
+++ b/dopamine/core/Dockerfile
@@ -1,0 +1,39 @@
+# If you want to use a different version of CUDA, view the available
+# images here: https://hub.docker.com/r/nvidia/cuda
+# Note:
+#   - Jax currently supports CUDA versions up to 11.3.
+#   - Tensorflow required CUDA versions after 11.2.
+ARG cuda_docker_tag="12.1.1-cudnn8-devel-ubuntu20.04"
+FROM nvidia/cuda:${cuda_docker_tag}
+
+
+RUN apt-get update
+# tzdata is required below. To avoid hanging, install it first.
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install tzdata -y
+RUN apt-get install git wget libgl1-mesa-glx -y
+
+# Install python3.8.
+RUN apt-get install software-properties-common -y
+RUN add-apt-repository ppa:deadsnakes/ppa -y
+RUN apt-get install python3.8 -y
+
+# Make python3.8 the default python.
+RUN rm /usr/bin/python3
+RUN ln -s /usr/bin/python3.8 /usr/bin/python3
+RUN ln -s /usr/bin/python3.8 /usr/bin/python
+RUN apt-get install python3-distutils -y
+
+# Install pip.
+RUN wget https://bootstrap.pypa.io/get-pip.py
+RUN python get-pip.py
+RUN rm get-pip.py
+
+COPY ./submodule/ /root/dopamine/
+
+# Install Dopamine dependencies.
+RUN pip install -r /root/dopamine/requirements.txt
+
+# Install JAX for GPU, overriding requirements.txt.
+RUN pip install --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+
+WORKDIR /root/dopamine


### PR DESCRIPTION
This adds the Dopamine library as a git submodule. The intended way to use Dopamine is copying+modifying instead of installing as a python library, so a git submodule allows us to do that. The version (i.e. git commit hash) of Dopamine is locked, so no fear of versions changing out from under us.

Build script relies on Docker build. I didn't like Dopamine's docker files, so I pulled them out of the repo and modified them in our own repo.