### PR TITLE
Removing hardcoded paths for chinese checkers

### DIFF
--- a/chinese_checkers/CMakeLists.txt
+++ b/chinese_checkers/CMakeLists.txt
@@ -12,7 +12,8 @@ include_directories("cc"
     "utils" 
     "players"
     "solve"
-    ${PYTHON_INCLUDE_DIRS})
+    ${PYTHON_INCLUDE_DIRS}
+    ${pybind11_INCLUDE_DIR})
 
 add_subdirectory(utils)
 add_subdirectory(cc)
@@ -24,11 +25,13 @@ add_subdirectory(python2)
 pybind11_add_module(ccwrapper python2/ccwrapper.cpp)
 target_link_libraries(ccwrapper PRIVATE utils cc players solve)
 
-add_executable(solve_cc solve/main.cpp)
+#add_executable(solve_cc solve/main.cpp)
+pybind11_add_module(solve_cc solve/main.cpp)
 target_include_directories(solve_cc PUBLIC utils cc solve)
 target_link_libraries(solve_cc PUBLIC utils cc solve)
 
-add_executable(game_cc game/Driver.cpp)
+#add_executable(game_cc game/Driver.cpp)
+pybind11_add_module(game_cc game/Driver.cpp)
 target_include_directories(game_cc PUBLIC utils cc players game)
 target_link_libraries(game_cc PUBLIC utils cc players game)
 

--- a/chinese_checkers/cc/CCheckers.cpp
+++ b/chinese_checkers/cc/CCheckers.cpp
@@ -6,8 +6,8 @@
 #include <vector>
 #include <assert.h>
 #include <algorithm>
-#include "/Users/bigyankarki/opt/anaconda3/envs/cc2/include/pybind11/pybind11.h"
-#include "/Users/bigyankarki/opt/anaconda3/envs/cc2/include/pybind11/numpy.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
 
 namespace py = pybind11;
 

--- a/chinese_checkers/cc/CCheckers.h
+++ b/chinese_checkers/cc/CCheckers.h
@@ -2,8 +2,8 @@
 #include <iostream>
 #include "screenUtil.h"
 #include <vector>
-#include "/Users/bigyankarki/opt/anaconda3/envs/cc2/include/pybind11/pybind11.h"
-#include "/Users/bigyankarki/opt/anaconda3/envs/cc2/include/pybind11/numpy.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
 
 namespace py = pybind11;
 

--- a/chinese_checkers/players/UCT.h
+++ b/chinese_checkers/players/UCT.h
@@ -17,8 +17,8 @@
 #include "Player.h"
 #include "CCheckers.h"
 #include "Timer.h"
-#include "/Users/bigyankarki/opt/anaconda3/envs/cc2/include/pybind11/pybind11.h"
-#include "/Users/bigyankarki/opt/anaconda3/envs/cc2/include/pybind11/stl.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 

--- a/chinese_checkers/python2/ccwrapper.cpp
+++ b/chinese_checkers/python2/ccwrapper.cpp
@@ -7,7 +7,7 @@
  *
 */
 
-#include </Users/bigyankarki/opt/anaconda3/envs/cc2/include/pybind11/pybind11.h>
+#include <pybind11/pybind11.h>
 #include <iostream>
 #include "CCheckers.h"
 #include "DistEval.h"

--- a/chinese_checkers/requirements_gpu.txt
+++ b/chinese_checkers/requirements_gpu.txt
@@ -3,11 +3,11 @@ astunparse==1.6.3
 cachetools==5.2.0
 certifi==2022.12.7
 charset-normalizer==2.1.1
-chex==0.1.5
+chex==0.1.6
 contourpy==1.0.7
 cycler==0.11.0
 distlib==0.3.6
-dm-haiku==0.0.10.dev0
+dm-haiku @ git+https://github.com/deepmind/dm-haiku
 dm-tree==0.1.7
 etils==0.7.1
 filelock==3.9.0
@@ -22,8 +22,9 @@ h5py==3.7.0
 idna==3.4
 importlib-metadata==6.6.0
 importlib-resources==5.9.0
+--find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 jax==0.4.12
-jaxlib==0.4.12+cuda11.cudnn86
+jaxlib[cuda12_pip]==0.4.12
 jmp==0.0.2
 keras==2.11.0
 kiwisolver==1.4.4
@@ -50,8 +51,6 @@ platformdirs==2.6.2
 protobuf==3.19.6
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pybind11 @ file:///home/conda/feedstock_root/build_artifacts/pybind11_1605158622735/work
-pybind11-global @ file:///home/conda/feedstock_root/build_artifacts/pybind11_1605158622735/work
 pyparsing==3.0.9
 python-dateutil==2.8.2
 requests==2.28.1


### PR DESCRIPTION
Used helper pybind11 to automatically add include dirs. Updated requirements to install latest CUDA version of jax. Update chex to 0.1.6 due to an XLA error